### PR TITLE
Pin excon gem to ~> 0.64

### DIFF
--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files lib README.md LICENSE`.split($\)
   gem.name          = 'docker-api'
   gem.version       = Docker::VERSION
-  gem.add_dependency 'excon', '>= 0.64.0'
+  gem.add_dependency 'excon', '~> 0.64'
   gem.add_dependency 'multi_json'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
excon 1.0.0 was released today (https://github.com/excon/excon/commit/33a071d992f04350c12918a9b259154df35c5332) and this has caused conflicts in our environment with `fog-core`.

Would you consider changing the constraint to `~> 0.64` until the next major release?

