### PR TITLE
Ensure that docker-api works with frozen strings

### DIFF
--- a/.cane
+++ b/.cane
@@ -1,2 +1,0 @@
---abc-max 30
---style-measure 120

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,6 +15,10 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.3
+          - 3.2
+          - 3.1
+          - '3.0'
           - 2.7
           - 2.6
           - 2.5
@@ -24,14 +28,13 @@ jobs:
           - ':27.'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: install bundler
-        run: |
-          gem install bundler -v '~> 1.17.3'
-          bundle update
+          bundler-cache: true
+      - name: Update gems
+        run: bundle update
       - name: install docker
         env:
           DOCKER_VERSION: ${{ matrix.docker_version }}
@@ -61,20 +64,23 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.3
+          - 3.2
+          - 3.1
+          - '3.0'
           - 2.7
           - 2.6
           - 2.5
           - 2.4
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: install bundler
-        run: |
-          gem install bundler -v '~> 1.17.3'
-          bundle update
+          bundler-cache: true
+      - name: Update gems
+        run: bundle update
       - name: install podman
         run: sudo ./script/install_podman.sh
       - name: spec tests

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   add_group 'Library', 'lib'
   add_group 'Specs', 'spec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,18 +4,12 @@ ENV['PATH'] = "/opt/docker/:#{ENV['PATH']}" if ENV['CI'] == 'true'
 
 require 'docker'
 require 'rspec/core/rake_task'
-require 'cane/rake_task'
-
 
 desc 'Run the full test suite from scratch'
-task :default => [:unpack, :rspec, :quality]
+task :default => [:unpack, :rspec]
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-end
-
-Cane::RakeTask.new(:quality) do |cane|
-  cane.canefile = '.cane'
 end
 
 desc 'Download the necessary base images'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 ENV['PATH'] = "/opt/docker/:#{ENV['PATH']}" if ENV['CI'] == 'true'

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,9 +33,6 @@ This repository comes with five Rake commands to assist in your testing of the c
 ## `rake rspec`
 This command will run Rspec tests normally on your local system. You must have all the required base images pulled.
 
-## `rake quality`
-This command runs a code quality threshold checker to hinder bad code.
-
 ## `rake unpack`
 Pulls down all the required base images for testing.
 

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-its'
-  gem.add_development_dependency 'cane'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'single_cov'
   gem.add_development_dependency 'webmock'

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 require File.expand_path('../lib/docker/version', __FILE__)
 
 Gem::Specification.new do |gem|

--- a/lib/docker-api.rb
+++ b/lib/docker-api.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'docker'

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 require 'multi_json'
 require 'excon'

--- a/lib/docker/base.rb
+++ b/lib/docker/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class is a base class for Docker Container and Image.
 # It is implementing accessor methods for the models attributes.
 module Docker::Base

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Connection to a Docker server. The Connection is
 # immutable in that once the url and options is set they cannot be changed.
 class Docker::Connection

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Docker Container. It's important to note that nothing
 # is cached so that the information is always up to date.
 class Docker::Container

--- a/lib/docker/error.rb
+++ b/lib/docker/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This module holds the Errors for the gem.
 module Docker::Error
 

--- a/lib/docker/event.rb
+++ b/lib/docker/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Docker Event.
 class Docker::Event
   include Docker::Error

--- a/lib/docker/exec.rb
+++ b/lib/docker/exec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Docker Exec Instance.
 class Docker::Exec
   include Docker::Base

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Docker Image.
 class Docker::Image
   include Docker::Base
@@ -28,7 +30,7 @@ class Docker::Image
     repo, tag = Docker::Util.parse_repo_tag(repo_tag)
     raise ArgumentError, "Image does not have a name to push." if repo.nil?
 
-    body = ""
+    body = +""
     credentials = creds || Docker.creds || {}
     headers = Docker::Util.build_auth_header(credentials)
     opts = {:tag => tag}.merge(options)
@@ -119,7 +121,7 @@ class Docker::Image
     def create(opts = {}, creds = nil, conn = Docker.connection, &block)
       credentials = creds.nil? ? Docker.creds : MultiJson.dump(creds)
       headers = credentials && Docker::Util.build_auth_header(credentials) || {}
-      body = ''
+      body = +''
       conn.post(
         '/images/create',
         opts,
@@ -168,7 +170,7 @@ class Docker::Image
         end
         nil
       else
-        string = ''
+        string = +''
         save_stream(names, {}, conn, &response_block_for_save(string))
         string
       end
@@ -196,7 +198,7 @@ class Docker::Image
     def load(tar, opts = {}, conn = Docker.connection, creds = nil, &block)
        headers = build_headers(creds)
        io = tar.is_a?(String) ? File.open(tar, 'rb') : tar
-       body = ""
+       body = +""
        conn.post(
          '/images/load',
          opts,
@@ -267,7 +269,7 @@ class Docker::Image
 
     # Given a Dockerfile as a string, builds an Image.
     def build(commands, opts = {}, connection = Docker.connection, &block)
-      body = ""
+      body = +""
       connection.post(
         '/build', opts,
         :body => Docker::Util.create_tar('Dockerfile' => commands),
@@ -288,7 +290,7 @@ class Docker::Image
       headers = build_headers(creds)
 
       # The response_block passed to Excon will build up this body variable.
-      body = ""
+      body = +""
       connection.post(
         '/build', opts,
         :headers => headers,
@@ -340,7 +342,7 @@ class Docker::Image
   # Convience method to get the Dockerfile for a file hash and a path to
   # output to.
   def dockerfile_for(file_hash, output_path)
-    dockerfile = "from #{self.id}\n"
+    dockerfile = +"from #{self.id}\n"
 
     file_hash.keys.each do |basename|
       dockerfile << "add #{basename} #{output_path}\n"

--- a/lib/docker/messages.rb
+++ b/lib/docker/messages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents all the messages either received by chunks from attach
 class Docker::Messages
 

--- a/lib/docker/messages_stack.rb
+++ b/lib/docker/messages_stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a messages stack
 class Docker::MessagesStack
 

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class represents a Docker Network.
 class Docker::Network
   include Docker::Base

--- a/lib/docker/rake_task.rb
+++ b/lib/docker/rake_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class allows image-based tasks to be created.
 class Docker::ImageTask < Rake::Task
   def self.scope_name(_scope, task_name)

--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 # This module holds shared logic that doesn't really belong anywhere else in the

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Docker
   # The version of the docker-api gem.
   VERSION = '2.3.0'

--- a/lib/docker/volume.rb
+++ b/lib/docker/volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # class represents a Docker Volume
 class Docker::Volume
   include Docker::Base

--- a/lib/excon/middlewares/hijack.rb
+++ b/lib/excon/middlewares/hijack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Excon
   module Middleware
     # Hijack is an Excon middleware which parses response headers and then

--- a/spec/cov_spec.rb
+++ b/spec/cov_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.not_covered!

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 12

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 39

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 5

--- a/spec/docker/exec_spec.rb
+++ b/spec/docker/exec_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 5

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 16
@@ -464,7 +466,7 @@ describe Docker::Image do
     end
 
     context 'with a block capturing create output' do
-      let(:create_output) { "" }
+      let(:create_output) { +"" }
       let(:block) { Proc.new { |chunk| create_output << chunk } }
 
       before do
@@ -537,7 +539,7 @@ describe Docker::Image do
     let(:non_streamed) do
       Docker.connection.get('/images/get', 'names' => image)
     end
-    let(:streamed) { '' }
+    let(:streamed) { +'' }
     let(:tar_files) do
       proc do |string|
         Gem::Package::TarReader
@@ -723,7 +725,7 @@ describe Docker::Image do
       end
 
       context 'with a block capturing build output' do
-        let(:build_output) { "" }
+        let(:build_output) { +"" }
         let(:block) { Proc.new { |chunk| build_output << chunk } }
         let!(:image) { subject.build("FROM debian:stable\n", &block) }
 
@@ -775,7 +777,7 @@ describe Docker::Image do
       end
 
       context 'with a block capturing build output' do
-        let(:build_output) { "" }
+        let(:build_output) { +"" }
         let(:block) { Proc.new { |chunk| build_output << chunk } }
 
         it 'calls the block and passes build output' do
@@ -784,7 +786,7 @@ describe Docker::Image do
         end
 
         context 'uses a cached version the second time' do
-          let(:build_output_two) { "" }
+          let(:build_output_two) { +"" }
           let(:block_two) { Proc.new { |chunk| build_output_two << chunk } }
           let(:image_two) { subject.build_from_dir(dir, opts, &block_two) }
 

--- a/spec/docker/messages_spec.rb
+++ b/spec/docker/messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 4

--- a/spec/docker/messages_stack.rb
+++ b/spec/docker/messages_stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered!

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 unless ::Docker.podman?

--- a/spec/docker/util_spec.rb
+++ b/spec/docker/util_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 require 'fileutils'

--- a/spec/docker/volume_spec.rb
+++ b/spec/docker/volume_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 1

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 SingleCov.covered! uncovered: 8

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
I think after Ruby 3.4 is released[^1], more people will start expecting libraries to be functional with e.g. the `--enable-frozen-string-literal` option enabled.

This PR adds the `frozen_string_literal` header to all files and fixes failing tests.

This PR also configures CI to run tests with Ruby versions 3.0 up to 3.3. This in turn means that the `cane` gem had to be removed. It was last updated 6 years ago, and [that last change](https://github.com/square/cane/commit/c8d6ce4e0092e5f677d3a2f409db7566e5d82136) was telling people to start using RuboCop instead (however, I feel such a change is out of scope for this PR).

[^1]:https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4