### PR TITLE
List base64 as a runtime dependency, add Ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.4
           - 3.3
           - 3.2
           - 3.1
@@ -64,6 +65,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.4
           - 3.3
           - 3.2
           - 3.1

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = Docker::VERSION
   gem.add_dependency 'excon', '>= 0.64.0'
   gem.add_dependency 'multi_json'
+  gem.add_dependency 'base64'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-its'


### PR DESCRIPTION
Since Ruby 3.4, base64 is no longer a default and needs to be installed explicitly: https://bugs.ruby-lang.org/issues/20187

